### PR TITLE
Also benchmark on main

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,5 @@ jobs:
         with:
           filePath: benchmark.md
           comment_tag: benchmark
-      - name: "Add benchmark to Job Summary"
-        run: |
-          cat benchmark.md >> $GITHUB_STEP_SUMMARY
+      - name: Add benchmark to Job Summary
+        run: cat benchmark.md >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,5 @@ jobs:
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-      - uses: mxschmitt/action-tmate@v3
       - name: Check workflow files
         run: ${{ steps.get_actionlint.outputs.executable }} -color


### PR DESCRIPTION
Cache sharing between sister branches [doesn't work on GitHub](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache). To still be able to share the cache, we can create the cache on main and then let the children branches use this cache.

This PR also adds the benchmark output to the Job Summary.