### PR TITLE
Automate version bumps

### DIFF
--- a/.github/scripts/read_version.sh
+++ b/.github/scripts/read_version.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # first get line with version_info, then extract thing in parantheses, then replace ", " with "."
-echo $(cat $1 | grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g")
+grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g"

--- a/.github/scripts/read_version.sh
+++ b/.github/scripts/read_version.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # first get line with version_info, then extract thing in parantheses, then replace ", " with "."
-grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g"
+echo $(cat $1 | grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g")

--- a/.github/scripts/read_version.sh
+++ b/.github/scripts/read_version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# first get line with version_info, then extract thing in parantheses, then replace ", " with "."
+grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,19 +24,19 @@ jobs:
   release:
     # if: github.ref == 'refs/heads/main'
     # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: [build]
+    # needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: artifact
+      #     path: dist
       - uses: Quantco/ui-actions/version-metadata@v1
         id: version-metadata
         with:
           file: slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
-          version-extraction-override: 'command:./.github/scripts/read_version.sh'
+          version-extraction-override: 'command:./read_version.sh'
       - run: |
           echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: Quantco/ui-actions/version-metadata@v1
         id: version-metadata
         with:
-          file: slim_trees/_version.py
+          file: ./slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
           version-extraction-override: 'command:./read_version.sh'
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,8 +36,7 @@ jobs:
         with:
           file: slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
-          # first get line with version_info, then extract thing in parantheses, then replace ", " with "."
-          version-extraction-override: 'command:grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g"'
+          version-extraction-override: 'command:.github/scripts/read_version.sh'
       - run: |
           echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
         with:
           file: ./slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
-          version-extraction-override: 'command:./.github/scripts/read_version.sh'
+          version-extraction-override: 'command:grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g"'
+          # version-extraction-override: 'command:./.github/scripts/read_version.sh'
       - run: |
           echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           file: slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
-          version-extraction-override: 'command:.github/scripts/read_version.sh'
+          version-extraction-override: 'command:./.github/scripts/read_version.sh'
       - run: |
           echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      version-changed: ${{ steps.version-metadata.outputs.changed }}
+      new-version: ${{ steps.version-metadata.outputs.newVersion }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -20,41 +23,40 @@ jobs:
         with:
           name: artifact
           path: dist/*
-
-  release:
-    # if: github.ref == 'refs/heads/main'
-    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    # needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: artifact
-      #     path: dist
       - uses: Quantco/ui-actions/version-metadata@v1
         id: version-metadata
         with:
           file: ./slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
           version-extraction-override: 'command:./.github/scripts/read_version.sh'
-      - run: |
-          echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
-      - run: |
-          echo "New version: ${{ steps.version-metadata.outputs.newVersion }}"
-      # - name: Publish package on TestPyPi
-      #   uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.TEST_PYPI_TOKEN }}
-      #     repository-url: https://test.pypi.org/legacy/
-      # - name: Publish package on PyPi
-      #   uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
-      #   with:
-      #     user: __token__
-      #     password: ${{ secrets.PYPI_TOKEN }}
-      # - name: Create release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     generate_release_notes: true
-      #     draft: true
+
+  release:
+    if: github.ref == 'refs/heads/main' && needs.build.outputs.version-changed == 'true'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - name: Publish package on TestPyPi
+        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish package on PyPi
+        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+      - name: Push v${{ needs.build.outputs.new-version }} tag
+        run: |
+          git tag v${{ needs.build.outputs.new-version }}
+          git push origin v${{ needs.build.outputs.new-version }}
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          tag_name: v${{ needs.build.outputs.new-version }}
+          draft: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
     # needs: [build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       # - uses: actions/download-artifact@v3
       #   with:
       #     name: artifact
@@ -36,7 +37,7 @@ jobs:
         with:
           file: ./slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
-          version-extraction-override: 'command:./read_version.sh'
+          version-extraction-override: 'command:./.github/scripts/read_version.sh'
       - run: |
           echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,7 @@ jobs:
         with:
           file: ./slim_trees/_version.py
           token: ${{ secrets.GITHUB_TOKEN }}
-          version-extraction-override: 'command:grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g"'
-          # version-extraction-override: 'command:./.github/scripts/read_version.sh'
+          version-extraction-override: 'command:./.github/scripts/read_version.sh'
       - run: |
           echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
       - run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,8 @@ jobs:
           path: dist/*
 
   release:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.ref == 'refs/heads/main'
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -30,19 +31,30 @@ jobs:
         with:
           name: artifact
           path: dist
-      - name: Publish package on TestPyPi
-        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
+      - uses: Quantco/ui-actions/version-metadata@v1
+        id: version-metadata
         with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-      - name: Publish package on PyPi
-        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-      - name: Create release
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          draft: true
+          file: slim_trees/_version.py
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # first get line with version_info, then extract thing in parantheses, then replace ", " with "."
+          version-extraction-override: 'command:grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g"'
+      - run: |
+          echo "Version changed: ${{ steps.version-metadata.outputs.changed }}"
+      - run: |
+          echo "New version: ${{ steps.version-metadata.outputs.newVersion }}"
+      # - name: Publish package on TestPyPi
+      #   uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.TEST_PYPI_TOKEN }}
+      #     repository-url: https://test.pypi.org/legacy/
+      # - name: Publish package on PyPi
+      #   uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598
+      #   with:
+      #     user: __token__
+      #     password: ${{ secrets.PYPI_TOKEN }}
+      # - name: Create release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     generate_release_notes: true
+      #     draft: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,22 +57,3 @@ python_version = "3.8"
 ignore_missing_imports = true
 no_implicit_optional = true
 check_untyped_defs = true
-
-[tool.tbump.version]
-current = "0.2.0"
-regex = '''
-  (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.(?P<extra>.+))?
-'''
-
-[[tool.tbump.field]]
-name = "extra"
-default = ""
-
-[[tool.tbump.file]]
-src = "slim_trees/_version.py"
-version_template = '({major}, {minor}, {patch}, "{extra}")'
-search = "version_info = {current_version}"
-
-[tool.tbump.git]
-message_template = "Bump to {new_version}"
-tag_template = "v{new_version}"

--- a/read_version.sh
+++ b/read_version.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# first get line with version_info, then extract thing in parantheses, then replace ", " with "."
-echo $(cat $1 | grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g")

--- a/read_version.sh
+++ b/read_version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# first get line with version_info, then extract thing in parantheses, then replace ", " with "."
+echo $(cat $1 | grep "version_info =" | sed "s/^.*(\([^()]*\)).*$/\1/" | sed "s/, /./g")

--- a/slim_trees/_version.py
+++ b/slim_trees/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 2, 0, "")
-__version__ = ".".join(filter(lambda s: len(s) > 0, map(str, version_info)))
+version_info = (0, 2, 0)
+__version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Use `quantco/ui-actions/version-metadata` instead of tbump. This actions checks the `slim_trees/_version.py` for a new version and releases if on main.