### PR TITLE
Allow for custom unpickler in load(s)_compressed

### DIFF
--- a/environment-deprecated.yml
+++ b/environment-deprecated.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - lightgbm
+  - lightgbm <4.0
   - numpy
   - python>=3.8
   - pre-commit

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ lint = "pre-commit run --all"
 [dependencies]
 python = ">=3.8"
 pip = "*"
-lightgbm = "*"
+lightgbm = "<4.0"
 numpy = "*"
 pre-commit = "*"
 pandas = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project] # TODO: move to pyproject.toml once pixi supports it
 name = "slim-trees"
-version = "0.2.1"
+version = "0.2.2"
 description = "A python package for efficient pickling of ML models."
 authors = ["Pavel Zwerschke <pavelzw@gmail.com>"]
 channels = ["conda-forge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "slim-trees"
 description = "A python package for efficient pickling of ML models."
-version = "0.2.1"
+version = "0.2.2"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 lightgbm = [
-    "lightgbm",
+    "lightgbm <4.0",
 ]
 scikit-learn = [
     "scikit-learn <1.3.0",


### PR DESCRIPTION
This is useful to restrict possible imports or to allow unpickling when required module or function names have been refactored.