### PR TITLE
Adding support for numpy 2

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3289,7 +3289,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.10.0-py312h9a8786e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.0-py312h22e1c76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py312h1d6d2e6_1.conda
@@ -3353,7 +3353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mypy-1.10.0-py312h396f95a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.0.0-py312hd0593b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-2.2.2-py312h14eacfc_1.conda
@@ -3411,7 +3411,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.10.0-py312h5fa3f64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.0-py312h8813227_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py312h1171441_1.conda
@@ -3469,7 +3469,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.10.0-py312h4a164c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.0-py312hb544834_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.2-py312h8ae5369_1.conda
@@ -3526,7 +3526,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_692.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.10.0-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.0-py312h49bc9c5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py312h72972c8_1.conda
@@ -5623,7 +5623,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.10.0-py39hd3abc70_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py39h474f0d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.0-py39ha0965c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.1-h4ab18f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py39hfc16268_1.conda
@@ -5686,7 +5686,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mypy-1.10.0-py39he257ee7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py39h91c28bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.0.0-py39hcdcdb6f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.1-h68df207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-2.2.2-py39h60c7704_1.conda
@@ -5743,7 +5743,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.10.0-py39ha624472_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py39h28c39a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.0-py39h3fadf17_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.1-h87427d6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.2-py39hbb604f3_1.conda
@@ -5800,7 +5800,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.10.0-py39h7e7fbb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py39h7aa2656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.0-py39h19d27af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.1-hfb2fe0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.2-py39h998126f_1.conda
@@ -5856,7 +5856,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.1.0-h66d3029_692.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.10.0-py39ha55e580_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py39hddb5d58_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.0-py39h60232e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.2-py39h2366fc2_1.conda
@@ -10167,6 +10167,232 @@ packages:
   license_family: BSD
   size: 5920615
   timestamp: 1707226471242
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py312h22e1c76_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.0-py312h22e1c76_0.conda
+  sha256: e5fc4a1053c8f02db78d4a50733d6c84d04e3c781749ae7478876ecdcd8c87ca
+  md5: 7956c7d65f87aecaba720af6088e72c3
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8352992
+  timestamp: 1718615528478
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py312h49bc9c5_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.0-py312h49bc9c5_0.conda
+  sha256: a2a4f9c90076d70a9e40aebe7ea323e67803af1cf4e6fff759af330726b2644d
+  md5: 8f8c23e8087dbb05828be5abbeac347d
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6988383
+  timestamp: 1718615911404
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py312h8813227_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.0-py312h8813227_0.conda
+  sha256: c83b985945095b04c4ba4828eea4ddb0b9b5546518b39d4b91c32afbf7838cde
+  md5: 814dba0ed2de85d89e09a5b811024a86
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7479080
+  timestamp: 1718615564653
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py312hb544834_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.0-py312hb544834_0.conda
+  sha256: 7015b30c00e8eb6a8abd639a7683f3c57b2abd090e74cda6179ab5f5d6974575
+  md5: 2ee98af1e5c917e3e1410758ab889e7a
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6359802
+  timestamp: 1718615501795
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py312hd0593b1_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.0.0-py312hd0593b1_0.conda
+  sha256: 381007a6fa6a664cdd9e6d82128a9e7e8b5dd9639101a7524758fc09b2542ac1
+  md5: d4fdd581ae5e0c9ea804d9f208d5ca71
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7047500
+  timestamp: 1718615562238
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py39h19d27af_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.0.0-py39h19d27af_0.conda
+  sha256: fd23f589f408a352513cc96f13b40dd4065f8b7f2eb68ee106564b160577f2f7
+  md5: 8b1ce694d0d09daba22f0aead6be06e5
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5717263
+  timestamp: 1718615707984
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py39h3fadf17_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.0.0-py39h3fadf17_0.conda
+  sha256: a127611a1e0aedf7488b954bc26134ce165d9328fc096ef9ee08b482eca7a712
+  md5: c53be1a84e67ce8572e1e83f601068eb
+  depends:
+  - __osx >=10.13
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6903985
+  timestamp: 1718615618503
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py39h60232e0_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.0.0-py39h60232e0_0.conda
+  sha256: edaaa125626b271104a4323706061f867bf0dc8c4c82ffa5d53b97cc5d932a5e
+  md5: a0e44751d8bc67ef2932d832304872a9
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6319748
+  timestamp: 1718615955871
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py39ha0965c0_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.0.0-py39ha0965c0_0.conda
+  sha256: 2dc55ac4074f99ff2ca040f460e98189398548dc2148ab895c5b8d417641a715
+  md5: b411be2728ba5711fc9bcdb0efa2db71
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7755925
+  timestamp: 1718615443567
+- kind: conda
+  name: numpy
+  version: 2.0.0
+  build: py39hcdcdb6f_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.0.0-py39hcdcdb6f_0.conda
+  sha256: 6f36d16d296f5b123ec27435ecc5a1b85220db1a1ff06c9f3a11569397203743
+  md5: 8ba5676e972e45d1c0d947f169c6e914
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.9,<3.10.0a0
+  - python >=3.9,<3.10.0a0 *_cpython
+  - python_abi 3.9.* *_cp39
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6572750
+  timestamp: 1718615437630
 - kind: conda
   name: openssl
   version: 3.3.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,7 +9,7 @@ postinstall = "pip install --no-build-isolation --no-deps --disable-pip-version-
 
 [dependencies]
 python = ">=3.8"
-numpy = "*"
+numpy = ">=1,<3"
 
 [host-dependencies]
 pip = "*"
@@ -49,6 +49,10 @@ scikit-learn = ">=1.3,<1.4"
 scikit-learn = ">=1.4,<1.5"
 [feature.skl15.dependencies]
 scikit-learn = ">=1.5,<1.6"
+[feature.np1.dependencies]
+numpy = "1.*"
+[feature.np2.dependencies]
+numpy = "2.*"
 [feature.py38.dependencies]
 python = ">=3.8,<3.9"
 [feature.py39.dependencies]
@@ -71,20 +75,20 @@ pre-commit-run = "pre-commit run -a"
 
 [environments]
 default = ["test"]
-skl11 = ["py38", "skl11", "test"]
-skl12 = ["py38", "skl12", "test"]
-skl13 = ["py38", "skl13", "test"]
-skl14 = ["py39", "skl14", "test"]
-skl15 = ["py39", "skl15", "test"]
-lgbm32 = ["py38", "lgbm32", "test"]
-lgbm33 = ["py38", "lgbm33", "test"]
-lgbm40 = ["py38", "lgbm40", "test"]
-lgbm41 = ["py38", "lgbm41", "test"]
-lgbm42 = ["py38", "lgbm42", "test"]
-lgbm43 = ["py38", "lgbm43", "test"]
-py38 = ["py38", "test"]
-py39 = ["py39", "test"]
-py310 = ["py310", "test"]
-py311 = ["py311", "test"]
-py312 = ["py312", "test"]
+skl11 = ["py38", "skl11", "test", "np1"]
+skl12 = ["py38", "skl12", "test", "np1"]
+skl13 = ["py38", "skl13", "test", "np1"]
+skl14 = ["py39", "skl14", "test", "np1"]
+skl15 = ["py39", "skl15", "test", "np2"]
+lgbm32 = ["py38", "lgbm32", "test", "np1"]
+lgbm33 = ["py38", "lgbm33", "test", "np1"]
+lgbm40 = ["py38", "lgbm40", "test", "np1"]
+lgbm41 = ["py38", "lgbm41", "test", "np1"]
+lgbm42 = ["py38", "lgbm42", "test", "np1"]
+lgbm43 = ["py38", "lgbm43", "test", "np1"]
+py38 = ["py38", "test", "np1"]
+py39 = ["py39", "test", "np1"]
+py310 = ["py310", "test", "np1"]
+py311 = ["py311", "test", "np1"]
+py312 = ["py312", "test", "np2"]
 lint = { features = ["lint"], no-default-feature = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,38 +7,28 @@ name = "slim-trees"
 description = "A python package for efficient pickling of ML models."
 version = "0.2.10"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 requires-python = ">=3.8"
-authors = [
-    { name = "Pavel Zwerschke", email = "pavel.zwerschke@quantco.com" },
-]
+authors = [{ name = "Pavel Zwerschke", email = "pavel.zwerschke@quantco.com" }]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
-dependencies = [
-    "numpy",
-]
+dependencies = ["numpy >=1,<3"]
 
 [project.optional-dependencies]
-lightgbm = [
-    "lightgbm >=3.2,<4.4",
-]
-scikit-learn = [
-    "scikit-learn >=1.1.0,<1.6",
-]
+lightgbm = ["lightgbm >=3.2,<4.4"]
+scikit-learn = ["scikit-learn >=1.1.0,<1.6"]
 
 [project.urls]
 Homepage = "https://github.com/quantco/slim-trees"
 
 [tool.hatch.build.targets.sdist]
-include = [
-    "/slim_trees",
-]
+include = ["/slim_trees"]
 
 [tool.ruff]
 line-length = 88
@@ -46,37 +36,38 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = [
-    # pyflakes
-    "F",
-    # pycodestyle
-    "E", "W",
-    # flake8-builtins
-    "A",
-    # flake8-bugbear
-    "B",
-    # flake8-comprehensions
-    "C4",
-    # flake8-simplify
-    "SIM",
-    # flake8-unused-arguments
-    "ARG",
-    # pylint
-    "PL",
-    # tidy
-    "TID",
-    # isort
-    "I",
-    # pep8-naming
-    "N",
-    # pyupgrade
-    "UP"
+  # pyflakes
+  "F",
+  # pycodestyle
+  "E",
+  "W",
+  # flake8-builtins
+  "A",
+  # flake8-bugbear
+  "B",
+  # flake8-comprehensions
+  "C4",
+  # flake8-simplify
+  "SIM",
+  # flake8-unused-arguments
+  "ARG",
+  # pylint
+  "PL",
+  # tidy
+  "TID",
+  # isort
+  "I",
+  # pep8-naming
+  "N",
+  # pyupgrade
+  "UP",
 ]
 ignore = [
-    # variable in function should be lowercase
-    "N806",
-    # may cause conflicts with ruff formatter
-    "E501",
-    "W191",
+  # variable in function should be lowercase
+  "N806",
+  # may cause conflicts with ruff formatter
+  "E501",
+  "W191",
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "slim-trees"
 description = "A python package for efficient pickling of ML models."
-version = "0.2.10"
+version = "0.2.11"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"

--- a/slim_trees/compression_utils.py
+++ b/slim_trees/compression_utils.py
@@ -22,14 +22,16 @@ def can_cast(value: Any, dtype: DTypeLike) -> bool:
     scalar_type = np.min_scalar_type(value)
 
     return np.can_cast(scalar_type, dtype) or (
-        scalar_type.kind == "u" and value <= np.iinfo(dtype).max
+        scalar_type.kind == "u"
+        and np.issubdtype(dtype, np.integer)
+        and value <= np.iinfo(dtype).max
     )
 
 
 def safe_cast(arr: NDArray, dtype: DTypeLike) -> NDArray:
     if can_cast(arr.max(), dtype) and can_cast(arr.min(), dtype):
         return arr.astype(dtype)
-    raise ValueError(f"Cannot cast {arr.max().dtype} and {arr.min().dtype} to {dtype}.")
+    raise ValueError(f"Cannot cast array to {dtype}.")
 
 
 def _is_in_neighborhood_of_int(arr: NDArray, iinfo: np.iinfo, eps: float = 1e-12):

--- a/slim_trees/compression_utils.py
+++ b/slim_trees/compression_utils.py
@@ -23,7 +23,7 @@ def can_cast(value: Any, dtype: DTypeLike) -> bool:
 
     return np.can_cast(scalar_type, dtype) or (
         scalar_type.kind == "u"
-        and np.issubdtype(dtype, np.integer)
+        and np.issubdtype(dtype, np.signedinteger)
         and value <= np.iinfo(dtype).max
     )
 


### PR DESCRIPTION
<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->

Adhering to [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html#impact-on-can-cast), `np.can_cast` no longer applies any value-based logic for 0-D arrays and NumPy scalars.

Using `np.min_scalar_type(value)`, the data type with the smallest size and smallest scalar kind that can hold `value` is checked against `dtype`. 

However, there is still another issue due to the below schema of numpy 2.0.0's promotion rules:
![image](https://github.com/user-attachments/assets/80bd7be6-44e0-44b0-a131-d25433c00506)

For example, in the case of casting `np.int64(5)` to `np.int8` , `np.min_scalar_type(np.int64(5))` returns `np.uint8`, and according to the diagram, `np.uint8` can not be casted to `np.int8`. I have manually checked if `value` is of kind `uint` and dtype is of kind `np.signedinteger` and if the casting can safely happen.