### PR TITLE
Switch to OIDC publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,23 +36,15 @@ jobs:
   release:
     if: github.event_name == 'push' && github.ref_name == 'main' && needs.build.outputs.version-changed == 'true'
     needs: [build]
+    environment: pypi
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: artifact
           path: dist
-      - name: Publish package on TestPyPi
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-        with:
-          user: __token__
-          password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
       - name: Publish package on PyPi
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Push v${{ needs.build.outputs.new-version }} tag
         run: |


### PR DESCRIPTION
Removed TestPyPi publishing step from release workflow.

<!-- ⚠️ This is an open-source repository. Do not share sensitive information. -->
